### PR TITLE
Add support for push based brokers like RabbitMQ

### DIFF
--- a/brokers/rabbitmq/broker_test.go
+++ b/brokers/rabbitmq/broker_test.go
@@ -76,7 +76,7 @@ func TestNewBroker(t *testing.T) {
 	require.NotNil(t, broker)
 	assert.Equal(t, options, broker.options)
 	assert.Equal(t, serializer, broker.serializer)
-	assert.NotNil(t, broker.queues)
+	assert.NotNil(t, broker.declaredQueues)
 }
 
 func TestRabbitMQBroker_Type(t *testing.T) {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -23,7 +23,6 @@ func TestEngine_Start_Success(t *testing.T) {
 
 	err := engine.Start(ctx)
 	assert.NoError(t, err)
-	assert.NotNil(t, engine.poller)
 	assert.NotNil(t, engine.workerPool)
 
 	err = engine.Stop()

--- a/core/helpers_test.go
+++ b/core/helpers_test.go
@@ -167,8 +167,8 @@ func (b *PollerBuilder) WithInterval(interval time.Duration) *PollerBuilder {
 }
 
 // Build creates the poller
-func (b *PollerBuilder) Build() *Poller {
-	return NewPoller(b.setup.Broker, b.setup.Stats, b.queues, b.interval, b.jobChan, b.setup.Logger)
+func (b *PollerBuilder) Build() *StandardPoller {
+	return NewStandardPoller(b.setup.Broker, b.setup.Stats, b.queues, b.interval, b.setup.Logger)
 }
 
 // WorkerPoolBuilder helps create worker pools for testing

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -81,6 +81,12 @@ type Registry interface {
 	Clear()
 }
 
+// Poller interface defines what core needs from a job poller/consumer
+type Poller interface {
+	// Start begins consuming jobs and sending them to the job channel
+	Start(ctx context.Context, jobChan chan<- job.Job) error
+}
+
 // Serializer interface defines what core needs from a serializer
 type Serializer interface {
 	// Serialize converts a job to bytes


### PR DESCRIPTION
Push based brokers can perform better without polling. Poller is essentially an adapter which converts pull based requests into job channels, but a push based broker can expose a channel directly.

With this change a push based broker can implement poller interface and directly expose a job channel without a need for a poller.