### PR TITLE
Simplify Engine and Broker Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ func main() {
 		broker,
 		stats,
 		registry,
-		serializer,
 		core.WithConcurrency(10),
 		core.WithShutdownTimeout(30*time.Second),
 		core.WithJobBufferSize(200),

--- a/brokers/rabbitmq/broker.go
+++ b/brokers/rabbitmq/broker.go
@@ -103,16 +103,6 @@ func (r *RabbitMQBroker) Type() string {
 	return "rabbitmq"
 }
 
-// Capabilities returns RabbitMQ broker capabilities
-func (r *RabbitMQBroker) Capabilities() core.BrokerCapabilities {
-	return core.BrokerCapabilities{
-		SupportsAck:        true, // RabbitMQ supports ACK/NACK
-		SupportsDelay:      true, // Can be implemented with delayed exchange plugin
-		SupportsPriority:   true, // RabbitMQ supports message priority
-		SupportsDeadLetter: true, // RabbitMQ supports dead letter exchanges
-	}
-}
-
 // Enqueue adds a job to the queue
 func (r *RabbitMQBroker) Enqueue(ctx context.Context, j job.Job) error {
 	channel, err := r.getChannel()

--- a/brokers/rabbitmq/broker_test.go
+++ b/brokers/rabbitmq/broker_test.go
@@ -16,7 +16,6 @@ type mockSerializer struct {
 	serializeErr   error
 	deserializeErr error
 	format         string
-	useNumber      bool
 }
 
 func (m *mockSerializer) Serialize(j job.Job) ([]byte, error) {

--- a/brokers/rabbitmq/broker_test.go
+++ b/brokers/rabbitmq/broker_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/BranchIntl/goworker2/core"
 	"github.com/BranchIntl/goworker2/errors"
 	"github.com/BranchIntl/goworker2/job"
 	"github.com/stretchr/testify/assert"
@@ -40,9 +39,7 @@ func (m *mockSerializer) Deserialize(data []byte, metadata job.Metadata) (job.Jo
 	}, nil
 }
 
-func (m *mockSerializer) GetFormat() string           { return m.format }
-func (m *mockSerializer) UseNumber() bool             { return m.useNumber }
-func (m *mockSerializer) SetUseNumber(useNumber bool) { m.useNumber = useNumber }
+func (m *mockSerializer) GetFormat() string { return m.format }
 
 // mockJob is a simple job implementation for testing
 type mockJob struct {
@@ -162,7 +159,7 @@ func TestRabbitMQBroker_CreateQueue_NotConnected(t *testing.T) {
 	broker := NewBroker(DefaultOptions(), &mockSerializer{})
 	ctx := context.Background()
 
-	queueOptions := core.QueueOptions{
+	queueOptions := QueueOptions{
 		MaxRetries:      3,
 		MessageTTL:      5 * time.Minute,
 		DeadLetterQueue: "dlq",

--- a/brokers/rabbitmq/broker_test.go
+++ b/brokers/rabbitmq/broker_test.go
@@ -84,20 +84,6 @@ func TestRabbitMQBroker_Type(t *testing.T) {
 	assert.Equal(t, "rabbitmq", broker.Type())
 }
 
-func TestRabbitMQBroker_Capabilities(t *testing.T) {
-	broker := NewBroker(DefaultOptions(), &mockSerializer{})
-	capabilities := broker.Capabilities()
-
-	expected := core.BrokerCapabilities{
-		SupportsAck:        true,
-		SupportsDelay:      true,
-		SupportsPriority:   true,
-		SupportsDeadLetter: true,
-	}
-
-	assert.Equal(t, expected, capabilities)
-}
-
 func TestRabbitMQBroker_Connect_InvalidURI(t *testing.T) {
 	tests := []struct {
 		name string

--- a/brokers/rabbitmq/options.go
+++ b/brokers/rabbitmq/options.go
@@ -6,6 +6,7 @@ type Options struct {
 	PrefetchCount int
 	Exchange      string
 	ExchangeType  string
+	Queues        []string
 }
 
 // DefaultOptions returns default RabbitMQ options
@@ -15,5 +16,6 @@ func DefaultOptions() Options {
 		PrefetchCount: 1,
 		Exchange:      "activejob",
 		ExchangeType:  "direct",
+		Queues:        []string{},
 	}
 }

--- a/brokers/redis/broker.go
+++ b/brokers/redis/broker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/BranchIntl/goworker2/errors"
 	redisUtils "github.com/BranchIntl/goworker2/internal/redis"
 	"github.com/BranchIntl/goworker2/job"
+	"github.com/BranchIntl/goworker2/pollers"
 	"github.com/gomodule/redigo/redis"
 )
 
@@ -156,6 +157,11 @@ func (r *RedisBroker) Dequeue(ctx context.Context, queue string) (job.Job, error
 	return j, nil
 }
 
+func (r *RedisBroker) Start(ctx context.Context, jobChan chan<- job.Job) error {
+	poller := pollers.NewStandardPoller(r, r.options.Queues, r.options.PollInterval)
+	return poller.Start(ctx, jobChan)
+}
+
 // Ack acknowledges job completion (no-op for Redis)
 func (r *RedisBroker) Ack(ctx context.Context, j job.Job) error {
 	// Redis doesn't have built-in ACK mechanism
@@ -218,6 +224,11 @@ func (r *RedisBroker) QueueExists(ctx context.Context, name string) (bool, error
 	}
 
 	return exists, nil
+}
+
+// Queues returns the list of queues
+func (r *RedisBroker) Queues() []string {
+	return r.options.Queues
 }
 
 // QueueLength returns the number of jobs in a queue

--- a/brokers/redis/broker.go
+++ b/brokers/redis/broker.go
@@ -82,16 +82,6 @@ func (r *RedisBroker) Type() string {
 	return "redis"
 }
 
-// Capabilities returns Redis broker capabilities
-func (r *RedisBroker) Capabilities() core.BrokerCapabilities {
-	return core.BrokerCapabilities{
-		SupportsAck:        false, // Redis doesn't have built-in ACK
-		SupportsDelay:      false, // Could be implemented with sorted sets
-		SupportsPriority:   false, // Could be implemented with multiple queues
-		SupportsDeadLetter: false, // Could be implemented
-	}
-}
-
 // Enqueue adds a job to the queue
 func (r *RedisBroker) Enqueue(ctx context.Context, j job.Job) error {
 	if r.pool == nil {

--- a/brokers/redis/broker_test.go
+++ b/brokers/redis/broker_test.go
@@ -84,20 +84,6 @@ func TestRedisBroker_Type(t *testing.T) {
 	assert.Equal(t, "redis", broker.Type())
 }
 
-func TestRedisBroker_Capabilities(t *testing.T) {
-	broker := NewBroker(DefaultOptions(), &mockSerializer{})
-	capabilities := broker.Capabilities()
-
-	expected := core.BrokerCapabilities{
-		SupportsAck:        false,
-		SupportsDelay:      false,
-		SupportsPriority:   false,
-		SupportsDeadLetter: false,
-	}
-
-	assert.Equal(t, expected, capabilities)
-}
-
 func TestRedisBroker_Connect_InvalidURI(t *testing.T) {
 	tests := []struct {
 		name string

--- a/brokers/redis/broker_test.go
+++ b/brokers/redis/broker_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/BranchIntl/goworker2/core"
 	"github.com/BranchIntl/goworker2/errors"
 	"github.com/BranchIntl/goworker2/job"
 	"github.com/stretchr/testify/assert"
@@ -40,9 +39,7 @@ func (m *mockSerializer) Deserialize(data []byte, metadata job.Metadata) (job.Jo
 	}, nil
 }
 
-func (m *mockSerializer) GetFormat() string           { return m.format }
-func (m *mockSerializer) UseNumber() bool             { return m.useNumber }
-func (m *mockSerializer) SetUseNumber(useNumber bool) { m.useNumber = useNumber }
+func (m *mockSerializer) GetFormat() string { return m.format }
 
 // mockJob is a simple job implementation for testing
 type mockJob struct {
@@ -207,15 +204,6 @@ func TestRedisBroker_Nack(t *testing.T) {
 		// Should fail because Enqueue will fail when not connected
 		assert.ErrorIs(t, err, errors.ErrNotConnected)
 	})
-}
-
-func TestRedisBroker_CreateQueue(t *testing.T) {
-	broker := NewBroker(DefaultOptions(), &mockSerializer{})
-	ctx := context.Background()
-
-	// CreateQueue is a no-op for Redis
-	err := broker.CreateQueue(ctx, "test_queue", core.QueueOptions{})
-	assert.NoError(t, err)
 }
 
 func TestRedisBroker_Start_NotConnected(t *testing.T) {

--- a/brokers/redis/broker_test.go
+++ b/brokers/redis/broker_test.go
@@ -16,7 +16,6 @@ type mockSerializer struct {
 	serializeErr   error
 	deserializeErr error
 	format         string
-	useNumber      bool
 }
 
 func (m *mockSerializer) Serialize(j job.Job) ([]byte, error) {

--- a/brokers/redis/options.go
+++ b/brokers/redis/options.go
@@ -10,6 +10,12 @@ type Options struct {
 	// Namespace is the key prefix in Redis
 	Namespace string
 
+	// Queues is the list of queues to consume from
+	Queues []string
+
+	// PollInterval is the interval at which to poll for jobs
+	PollInterval time.Duration
+
 	// MaxConnections is the maximum number of connections in the pool
 	MaxConnections int
 
@@ -49,8 +55,13 @@ func (o Options) GetTLSCertPath() string           { return o.TLSCertPath }
 // DefaultOptions returns default Redis options
 func DefaultOptions() Options {
 	return Options{
+		// Redis broker options
+		Namespace:    "resque:",
+		Queues:       []string{},
+		PollInterval: 5 * time.Second,
+
+		// Redis connection options
 		URI:            "redis://localhost:6379/",
-		Namespace:      "resque:",
 		MaxConnections: 10,
 		MaxIdle:        2,
 		IdleTimeout:    240 * time.Second,

--- a/core/engine.go
+++ b/core/engine.go
@@ -16,11 +16,10 @@ import (
 
 // Engine is the main orchestration engine
 type Engine struct {
-	broker     Broker
-	stats      Statistics
-	registry   Registry
-	serializer Serializer
-	config     *Config
+	broker   Broker
+	stats    Statistics
+	registry Registry
+	config   *Config
 
 	workerPool *WorkerPool
 
@@ -34,7 +33,6 @@ func NewEngine(
 	broker Broker,
 	stats Statistics,
 	registry Registry,
-	serializer Serializer,
 	options ...EngineOption,
 ) *Engine {
 	config := defaultConfig()
@@ -43,11 +41,10 @@ func NewEngine(
 	}
 
 	return &Engine{
-		broker:     broker,
-		stats:      stats,
-		registry:   registry,
-		serializer: serializer,
-		config:     config,
+		broker:   broker,
+		stats:    stats,
+		registry: registry,
+		config:   config,
 	}
 }
 
@@ -73,7 +70,6 @@ func (e *Engine) Start(ctx context.Context) error {
 	e.workerPool = NewWorkerPool(
 		e.registry,
 		e.stats,
-		e.serializer,
 		e.config.Concurrency,
 		jobChan,
 		e.broker,

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -80,13 +80,12 @@ func TestEngine_Health_Healthy(t *testing.T) {
 	broker := NewMockBroker()
 	stats := NewMockStatistics()
 	registry := NewMockRegistry()
-	serializer := NewMockSerializer()
 
 	// Add some jobs to queues so the broker knows about them
 	broker.AddJobToQueue("queue1", NewMockJob("TestJob", "queue1", []interface{}{}))
 	broker.AddJobToQueue("queue2", NewMockJob("TestJob", "queue2", []interface{}{}))
 
-	engine := NewEngine(broker, stats, registry, serializer)
+	engine := NewEngine(broker, stats, registry)
 
 	ctx := context.Background()
 	err := engine.Start(ctx)
@@ -107,12 +106,11 @@ func TestEngine_Health_Unhealthy(t *testing.T) {
 	broker := NewMockBroker()
 	stats := NewMockStatistics()
 	registry := NewMockRegistry()
-	serializer := NewMockSerializer()
 
 	// Configure broker to report unhealthy
 	broker.SetHealthError(errors.New("broker is down"))
 
-	engine := NewEngine(broker, stats, registry, serializer)
+	engine := NewEngine(broker, stats, registry)
 
 	ctx := context.Background()
 	err := engine.Start(ctx)
@@ -130,9 +128,8 @@ func TestEngine_Register(t *testing.T) {
 	broker := NewMockBroker()
 	stats := NewMockStatistics()
 	registry := NewMockRegistry()
-	serializer := NewMockSerializer()
 
-	engine := NewEngine(broker, stats, registry, serializer)
+	engine := NewEngine(broker, stats, registry)
 
 	// Test registering a worker
 	err := engine.Register("TestJob", func(queue string, args ...interface{}) error {
@@ -150,9 +147,8 @@ func TestEngine_Run_ContextCancellation(t *testing.T) {
 	broker := NewMockBroker()
 	stats := NewMockStatistics()
 	registry := NewMockRegistry()
-	serializer := NewMockSerializer()
 
-	engine := NewEngine(broker, stats, registry, serializer,
+	engine := NewEngine(broker, stats, registry,
 		WithConcurrency(1),
 	)
 
@@ -183,9 +179,8 @@ func TestEngine_Integration_JobProcessing(t *testing.T) {
 	broker := NewMockBroker()
 	stats := NewMockStatistics()
 	registry := NewMockRegistry()
-	serializer := NewMockSerializer()
 
-	engine := NewEngine(broker, stats, registry, serializer,
+	engine := NewEngine(broker, stats, registry,
 		WithConcurrency(2),
 	)
 
@@ -235,9 +230,8 @@ func TestEngine_Integration_FailedJobProcessing(t *testing.T) {
 	broker := NewMockBroker()
 	stats := NewMockStatistics()
 	registry := NewMockRegistry()
-	serializer := NewMockSerializer()
 
-	engine := NewEngine(broker, stats, registry, serializer,
+	engine := NewEngine(broker, stats, registry,
 		WithConcurrency(1),
 	)
 
@@ -273,9 +267,8 @@ func TestEngine_Integration_MultipleQueues(t *testing.T) {
 	broker := NewMockBroker()
 	stats := NewMockStatistics()
 	registry := NewMockRegistry()
-	serializer := NewMockSerializer()
 
-	engine := NewEngine(broker, stats, registry, serializer,
+	engine := NewEngine(broker, stats, registry,
 		WithConcurrency(2),
 	)
 
@@ -329,9 +322,8 @@ func TestEngine_Start_WithShutdownTimeout(t *testing.T) {
 	broker := NewMockBroker()
 	stats := NewMockStatistics()
 	registry := NewMockRegistry()
-	serializer := NewMockSerializer()
 
-	engine := NewEngine(broker, stats, registry, serializer,
+	engine := NewEngine(broker, stats, registry,
 		WithConcurrency(1),
 		WithShutdownTimeout(50*time.Millisecond), // Very short timeout
 	)
@@ -370,9 +362,8 @@ func TestEngine_Health_QueueLengths(t *testing.T) {
 	broker := NewMockBroker()
 	stats := NewMockStatistics()
 	registry := NewMockRegistry()
-	serializer := NewMockSerializer()
 
-	engine := NewEngine(broker, stats, registry, serializer)
+	engine := NewEngine(broker, stats, registry)
 
 	// Add jobs to queues
 	job1 := NewMockJob("TestJob", "queue1", []interface{}{})

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -14,7 +14,6 @@ import (
 func TestEngine_Start_Success(t *testing.T) {
 	setup := NewTestSetup()
 	engine := setup.NewEngine().WithOptions(
-		WithQueues([]string{"test-queue"}),
 		WithConcurrency(2),
 	).Build()
 
@@ -64,8 +63,7 @@ func TestEngine_Stop_BeforeStart(t *testing.T) {
 func TestEngine_Stop_AfterStart(t *testing.T) {
 	setup := NewTestSetup()
 	engine := setup.NewEngine().WithOptions(
-		WithQueues([]string{"test-queue"}),
-		WithShutdownTimeout(100*time.Millisecond),
+		WithShutdownTimeout(100 * time.Millisecond),
 	).Build()
 
 	ctx, cancel := ContextWithCustomTimeout(t, 200*time.Millisecond)
@@ -84,9 +82,11 @@ func TestEngine_Health_Healthy(t *testing.T) {
 	registry := NewMockRegistry()
 	serializer := NewMockSerializer()
 
-	engine := NewEngine(broker, stats, registry, serializer,
-		WithQueues([]string{"queue1", "queue2"}),
-	)
+	// Add some jobs to queues so the broker knows about them
+	broker.AddJobToQueue("queue1", NewMockJob("TestJob", "queue1", []interface{}{}))
+	broker.AddJobToQueue("queue2", NewMockJob("TestJob", "queue2", []interface{}{}))
+
+	engine := NewEngine(broker, stats, registry, serializer)
 
 	ctx := context.Background()
 	err := engine.Start(ctx)
@@ -112,9 +112,7 @@ func TestEngine_Health_Unhealthy(t *testing.T) {
 	// Configure broker to report unhealthy
 	broker.SetHealthError(errors.New("broker is down"))
 
-	engine := NewEngine(broker, stats, registry, serializer,
-		WithQueues([]string{"test-queue"}),
-	)
+	engine := NewEngine(broker, stats, registry, serializer)
 
 	ctx := context.Background()
 	err := engine.Start(ctx)
@@ -128,7 +126,7 @@ func TestEngine_Health_Unhealthy(t *testing.T) {
 	assert.Contains(t, health.BrokerHealth.Error(), "broker is down")
 }
 
-func TestEngine_Enqueue(t *testing.T) {
+func TestEngine_Register(t *testing.T) {
 	broker := NewMockBroker()
 	stats := NewMockStatistics()
 	registry := NewMockRegistry()
@@ -136,19 +134,16 @@ func TestEngine_Enqueue(t *testing.T) {
 
 	engine := NewEngine(broker, stats, registry, serializer)
 
-	ctx := context.Background()
-	err := engine.Start(ctx)
-	require.NoError(t, err)
-	defer func() { _ = engine.Stop() }()
-
-	testJob := NewMockJob("TestJob", "test-queue", []interface{}{"arg1"})
-	err = engine.Enqueue(testJob)
+	// Test registering a worker
+	err := engine.Register("TestJob", func(queue string, args ...interface{}) error {
+		return nil
+	})
 	assert.NoError(t, err)
 
-	// Verify job was enqueued in broker
-	enqueuedJobs := broker.GetEnqueuedJobs()
-	assert.Len(t, enqueuedJobs, 1)
-	assert.Equal(t, testJob.GetID(), enqueuedJobs[0].GetID())
+	// Verify worker was registered
+	worker, exists := registry.Get("TestJob")
+	assert.True(t, exists)
+	assert.NotNil(t, worker)
 }
 
 func TestEngine_Run_ContextCancellation(t *testing.T) {
@@ -158,7 +153,6 @@ func TestEngine_Run_ContextCancellation(t *testing.T) {
 	serializer := NewMockSerializer()
 
 	engine := NewEngine(broker, stats, registry, serializer,
-		WithQueues([]string{"test-queue"}),
 		WithConcurrency(1),
 	)
 
@@ -192,9 +186,7 @@ func TestEngine_Integration_JobProcessing(t *testing.T) {
 	serializer := NewMockSerializer()
 
 	engine := NewEngine(broker, stats, registry, serializer,
-		WithQueues([]string{"test-queue"}),
 		WithConcurrency(2),
-		WithPollInterval(50*time.Millisecond),
 	)
 
 	// Register a test worker
@@ -246,9 +238,7 @@ func TestEngine_Integration_FailedJobProcessing(t *testing.T) {
 	serializer := NewMockSerializer()
 
 	engine := NewEngine(broker, stats, registry, serializer,
-		WithQueues([]string{"test-queue"}),
 		WithConcurrency(1),
-		WithPollInterval(50*time.Millisecond),
 	)
 
 	// Register a failing worker
@@ -286,9 +276,7 @@ func TestEngine_Integration_MultipleQueues(t *testing.T) {
 	serializer := NewMockSerializer()
 
 	engine := NewEngine(broker, stats, registry, serializer,
-		WithQueues([]string{"high", "medium", "low"}),
 		WithConcurrency(2),
-		WithPollInterval(50*time.Millisecond),
 	)
 
 	// Register workers
@@ -344,7 +332,6 @@ func TestEngine_Start_WithShutdownTimeout(t *testing.T) {
 	serializer := NewMockSerializer()
 
 	engine := NewEngine(broker, stats, registry, serializer,
-		WithQueues([]string{"test-queue"}),
 		WithConcurrency(1),
 		WithShutdownTimeout(50*time.Millisecond), // Very short timeout
 	)
@@ -385,9 +372,7 @@ func TestEngine_Health_QueueLengths(t *testing.T) {
 	registry := NewMockRegistry()
 	serializer := NewMockSerializer()
 
-	engine := NewEngine(broker, stats, registry, serializer,
-		WithQueues([]string{"queue1", "queue2"}),
-	)
+	engine := NewEngine(broker, stats, registry, serializer)
 
 	// Add jobs to queues
 	job1 := NewMockJob("TestJob", "queue1", []interface{}{})

--- a/core/helpers_test.go
+++ b/core/helpers_test.go
@@ -12,10 +12,9 @@ import (
 
 // TestSetup provides common test dependencies
 type TestSetup struct {
-	Broker     *MockBroker
-	Stats      *MockStatistics
-	Registry   *MockRegistry
-	Serializer *MockSerializer
+	Broker   *MockBroker
+	Stats    *MockStatistics
+	Registry *MockRegistry
 }
 
 // NewTestSetup creates a standard test setup with all mocks
@@ -27,10 +26,9 @@ func NewTestSetup() *TestSetup {
 	slog.SetDefault(logger)
 
 	return &TestSetup{
-		Broker:     NewMockBroker(),
-		Stats:      NewMockStatistics(),
-		Registry:   NewMockRegistry(),
-		Serializer: NewMockSerializer(),
+		Broker:   NewMockBroker(),
+		Stats:    NewMockStatistics(),
+		Registry: NewMockRegistry(),
 	}
 }
 
@@ -105,7 +103,7 @@ func (b *EngineBuilder) WithOptions(options ...EngineOption) *EngineBuilder {
 
 // Build creates the engine
 func (b *EngineBuilder) Build() *Engine {
-	return NewEngine(b.setup.Broker, b.setup.Stats, b.setup.Registry, b.setup.Serializer, b.options...)
+	return NewEngine(b.setup.Broker, b.setup.Stats, b.setup.Registry, b.options...)
 }
 
 // WorkerBuilder helps create workers for testing
@@ -157,8 +155,7 @@ func (b *WorkerPoolBuilder) WithConcurrency(concurrency int) *WorkerPoolBuilder 
 
 // Build creates the worker pool
 func (b *WorkerPoolBuilder) Build() *WorkerPool {
-	return NewWorkerPool(b.setup.Registry, b.setup.Stats, b.setup.Serializer,
-		b.concurrency, b.jobChan, b.setup.Broker)
+	return NewWorkerPool(b.setup.Registry, b.setup.Stats, b.concurrency, b.jobChan, b.setup.Broker)
 }
 
 // ErrorTestCase represents a common error test scenario

--- a/core/helpers_test.go
+++ b/core/helpers_test.go
@@ -110,17 +110,15 @@ func (b *EngineBuilder) Build() *Engine {
 
 // WorkerBuilder helps create workers for testing
 type WorkerBuilder struct {
-	setup  *TestSetup
-	id     string
-	queues []string
+	setup *TestSetup
+	id    string
 }
 
 // NewWorker starts building a test worker
 func (s *TestSetup) NewWorker() *WorkerBuilder {
 	return &WorkerBuilder{
-		setup:  s,
-		id:     "test-worker",
-		queues: []string{"test-queue"},
+		setup: s,
+		id:    "test-worker",
 	}
 }
 
@@ -130,57 +128,15 @@ func (b *WorkerBuilder) WithID(id string) *WorkerBuilder {
 	return b
 }
 
-// WithQueues sets the worker queues
-func (b *WorkerBuilder) WithQueues(queues []string) *WorkerBuilder {
-	b.queues = queues
-	return b
-}
-
 // Build creates the worker
 func (b *WorkerBuilder) Build() *Worker {
-	return NewWorker(b.id, b.queues, b.setup.Registry, b.setup.Stats, b.setup.Broker)
-}
-
-// PollerBuilder helps create pollers for testing
-type PollerBuilder struct {
-	setup    *TestSetup
-	queues   []string
-	interval time.Duration
-	jobChan  chan<- job.Job
-}
-
-// NewPoller starts building a test poller
-func (s *TestSetup) NewPoller(jobChan chan<- job.Job) *PollerBuilder {
-	return &PollerBuilder{
-		setup:    s,
-		queues:   []string{"test-queue"},
-		interval: 100 * time.Millisecond,
-		jobChan:  jobChan,
-	}
-}
-
-// WithQueues sets the poller queues
-func (b *PollerBuilder) WithQueues(queues []string) *PollerBuilder {
-	b.queues = queues
-	return b
-}
-
-// WithInterval sets the polling interval
-func (b *PollerBuilder) WithInterval(interval time.Duration) *PollerBuilder {
-	b.interval = interval
-	return b
-}
-
-// Build creates the poller
-func (b *PollerBuilder) Build() *StandardPoller {
-	return NewStandardPoller(b.setup.Broker, b.setup.Stats, b.queues, b.interval)
+	return NewWorker(b.id, b.setup.Registry, b.setup.Stats, b.setup.Broker)
 }
 
 // WorkerPoolBuilder helps create worker pools for testing
 type WorkerPoolBuilder struct {
 	setup       *TestSetup
 	concurrency int
-	queues      []string
 	jobChan     <-chan job.Job
 }
 
@@ -189,7 +145,6 @@ func (s *TestSetup) NewWorkerPool(jobChan <-chan job.Job) *WorkerPoolBuilder {
 	return &WorkerPoolBuilder{
 		setup:       s,
 		concurrency: 2,
-		queues:      []string{"test-queue"},
 		jobChan:     jobChan,
 	}
 }
@@ -200,16 +155,10 @@ func (b *WorkerPoolBuilder) WithConcurrency(concurrency int) *WorkerPoolBuilder 
 	return b
 }
 
-// WithQueues sets the worker pool queues
-func (b *WorkerPoolBuilder) WithQueues(queues []string) *WorkerPoolBuilder {
-	b.queues = queues
-	return b
-}
-
 // Build creates the worker pool
 func (b *WorkerPoolBuilder) Build() *WorkerPool {
 	return NewWorkerPool(b.setup.Registry, b.setup.Stats, b.setup.Serializer,
-		b.concurrency, b.queues, b.jobChan, b.setup.Broker)
+		b.concurrency, b.jobChan, b.setup.Broker)
 }
 
 // ErrorTestCase represents a common error test scenario

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -86,38 +86,6 @@ type Registry interface {
 	Get(class string) (WorkerFunc, bool)
 }
 
-// Serializer interface defines what core needs from a serializer
-type Serializer interface {
-	// Serialize converts a job to bytes
-	Serialize(job job.Job) ([]byte, error)
-
-	// Deserialize converts bytes to a job
-	Deserialize(data []byte, metadata job.Metadata) (job.Job, error)
-
-	// GetFormat returns the serialization format name
-	GetFormat() string
-
-	// UseNumber determines if numbers should be decoded as json.Number
-	UseNumber() bool
-
-	// SetUseNumber determines if numbers should be decoded as json.Number
-	SetUseNumber(useNumber bool)
-}
-
-// Supporting types used by the interfaces
-
-// QueueOptions for queue creation
-type QueueOptions struct {
-	// MaxRetries before moving to dead letter queue
-	MaxRetries int
-	// MessageTTL is how long a message can remain in queue
-	MessageTTL time.Duration
-	// VisibilityTimeout for message processing
-	VisibilityTimeout time.Duration
-	// DeadLetterQueue name for failed messages
-	DeadLetterQueue string
-}
-
 // WorkerInfo describes a worker
 type WorkerInfo struct {
 	ID       string

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -20,20 +20,13 @@ type Broker interface {
 	Ack(ctx context.Context, job job.Job) error
 	Nack(ctx context.Context, job job.Job, requeue bool) error
 
-	// Queue management
-	CreateQueue(ctx context.Context, name string, options QueueOptions) error
-	DeleteQueue(ctx context.Context, name string) error
-	QueueExists(ctx context.Context, name string) (bool, error)
+	// Queue introspection
 	QueueLength(ctx context.Context, name string) (int64, error)
 
 	// Connection management
 	Connect(ctx context.Context) error
 	Close() error
 	Health() error
-
-	// Broker-specific info
-	Type() string
-	Capabilities() BrokerCapabilities
 }
 
 // Statistics interface defines what core needs from a statistics backend
@@ -66,15 +59,6 @@ type Registry interface {
 
 	// Get retrieves a worker function by class
 	Get(class string) (WorkerFunc, bool)
-
-	// List returns all registered classes
-	List() []string
-
-	// Remove unregisters a worker function
-	Remove(class string) error
-
-	// Clear removes all registered workers
-	Clear()
 }
 
 // Poller interface defines what core needs from a job poller/consumer
@@ -100,14 +84,6 @@ type Serializer interface {
 }
 
 // Supporting types used by the interfaces
-
-// BrokerCapabilities describes what features a broker supports
-type BrokerCapabilities struct {
-	SupportsAck        bool
-	SupportsDelay      bool
-	SupportsPriority   bool
-	SupportsDeadLetter bool
-}
 
 // QueueOptions for queue creation
 type QueueOptions struct {

--- a/core/mocks_test.go
+++ b/core/mocks_test.go
@@ -488,56 +488,6 @@ func (m *MockRegistry) Clear() {
 	m.workers = make(map[string]WorkerFunc)
 }
 
-// MockSerializer implements the Serializer interface for testing
-type MockSerializer struct {
-	mu             sync.RWMutex
-	serializeErr   error
-	deserializeErr error
-	useNumber      bool
-}
-
-func NewMockSerializer() *MockSerializer {
-	return &MockSerializer{}
-}
-
-func (m *MockSerializer) Serialize(job job.Job) ([]byte, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	if m.serializeErr != nil {
-		return nil, m.serializeErr
-	}
-
-	return []byte(fmt.Sprintf(`{"class":"%s","args":%v}`, job.GetClass(), job.GetArgs())), nil
-}
-
-func (m *MockSerializer) Deserialize(data []byte, metadata job.Metadata) (job.Job, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	if m.deserializeErr != nil {
-		return nil, m.deserializeErr
-	}
-
-	return NewMockJob("test", "default", []interface{}{"arg1", "arg2"}), nil
-}
-
-func (m *MockSerializer) GetFormat() string {
-	return "mock"
-}
-
-func (m *MockSerializer) UseNumber() bool {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.useNumber
-}
-
-func (m *MockSerializer) SetUseNumber(useNumber bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.useNumber = useNumber
-}
-
 // MockJob implements the job.Job interface for testing
 type MockJob struct {
 	id         string

--- a/core/mocks_test.go
+++ b/core/mocks_test.go
@@ -24,7 +24,6 @@ type MockBroker struct {
 	queueLengthError         error
 	queues                   map[string][]job.Job
 	queueLengths             map[string]int64
-	capabilities             BrokerCapabilities
 	enqueuedJobs             []job.Job
 	ackedJobs                []job.Job
 	nackedJobs               []job.Job
@@ -35,12 +34,6 @@ func NewMockBroker() *MockBroker {
 	return &MockBroker{
 		queues:       make(map[string][]job.Job),
 		queueLengths: make(map[string]int64),
-		capabilities: BrokerCapabilities{
-			SupportsAck:        true,
-			SupportsDelay:      true,
-			SupportsPriority:   true,
-			SupportsDeadLetter: true,
-		},
 		enqueuedJobs: make([]job.Job, 0),
 		ackedJobs:    make([]job.Job, 0),
 		nackedJobs:   make([]job.Job, 0),
@@ -118,34 +111,6 @@ func (m *MockBroker) Nack(ctx context.Context, jobArg job.Job, requeue bool) err
 	return nil
 }
 
-func (m *MockBroker) CreateQueue(ctx context.Context, name string, options QueueOptions) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if m.queues[name] == nil {
-		m.queues[name] = make([]job.Job, 0)
-		m.queueLengths[name] = 0
-	}
-	return nil
-}
-
-func (m *MockBroker) DeleteQueue(ctx context.Context, name string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	delete(m.queues, name)
-	delete(m.queueLengths, name)
-	return nil
-}
-
-func (m *MockBroker) QueueExists(ctx context.Context, name string) (bool, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	_, exists := m.queues[name]
-	return exists, nil
-}
-
 func (m *MockBroker) QueueLength(ctx context.Context, name string) (int64, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -190,14 +155,6 @@ func (m *MockBroker) Health() error {
 	}
 
 	return nil
-}
-
-func (m *MockBroker) Type() string {
-	return "mock"
-}
-
-func (m *MockBroker) Capabilities() BrokerCapabilities {
-	return m.capabilities
 }
 
 // Test helpers

--- a/core/options.go
+++ b/core/options.go
@@ -7,8 +7,6 @@ import (
 // Config holds engine configuration
 type Config struct {
 	Concurrency     int
-	Queues          []string
-	PollInterval    time.Duration
 	ShutdownTimeout time.Duration
 	JobBufferSize   int
 }
@@ -20,8 +18,6 @@ type EngineOption func(*Config)
 func defaultConfig() *Config {
 	return &Config{
 		Concurrency:     25,
-		Queues:          []string{},
-		PollInterval:    5 * time.Second,
 		ShutdownTimeout: 30 * time.Second,
 		JobBufferSize:   100,
 	}
@@ -31,20 +27,6 @@ func defaultConfig() *Config {
 func WithConcurrency(n int) EngineOption {
 	return func(c *Config) {
 		c.Concurrency = n
-	}
-}
-
-// WithQueues sets the queues to process
-func WithQueues(queues []string) EngineOption {
-	return func(c *Config) {
-		c.Queues = queues
-	}
-}
-
-// WithPollInterval sets the polling interval
-func WithPollInterval(d time.Duration) EngineOption {
-	return func(c *Config) {
-		c.PollInterval = d
 	}
 }
 

--- a/core/options_test.go
+++ b/core/options_test.go
@@ -13,8 +13,6 @@ func TestMultipleOptions(t *testing.T) {
 	// Apply multiple options
 	options := []EngineOption{
 		WithConcurrency(15),
-		WithQueues([]string{"high", "medium", "low"}),
-		WithPollInterval(3 * time.Second),
 		WithShutdownTimeout(60 * time.Second),
 		WithJobBufferSize(500),
 	}
@@ -25,8 +23,6 @@ func TestMultipleOptions(t *testing.T) {
 
 	// Verify all options were applied
 	assert.Equal(t, 15, config.Concurrency)
-	assert.Equal(t, []string{"high", "medium", "low"}, config.Queues)
-	assert.Equal(t, 3*time.Second, config.PollInterval)
 	assert.Equal(t, 60*time.Second, config.ShutdownTimeout)
 	assert.Equal(t, 500, config.JobBufferSize)
 }

--- a/core/worker.go
+++ b/core/worker.go
@@ -17,7 +17,6 @@ type Worker struct {
 	id       string
 	hostname string
 	pid      int
-	queues   []string
 	registry Registry
 	stats    Statistics
 	broker   Broker
@@ -31,7 +30,6 @@ type Worker struct {
 // NewWorker creates a new worker
 func NewWorker(
 	id string,
-	queues []string,
 	registry Registry,
 	stats Statistics,
 	broker Broker,
@@ -42,7 +40,6 @@ func NewWorker(
 		id:        id,
 		hostname:  hostname,
 		pid:       os.Getpid(),
-		queues:    queues,
 		registry:  registry,
 		stats:     stats,
 		broker:    broker,
@@ -55,13 +52,6 @@ func (w *Worker) GetID() string {
 	return fmt.Sprintf("%s:%d-%s", w.hostname, w.pid, w.id)
 }
 
-// GetQueues returns the queues this worker processes.
-// Note: This is for informational purposes only (e.g., WorkerInfo reporting).
-// Workers receive jobs via channels from the Poller and don't poll queues directly.
-func (w *Worker) GetQueues() []string {
-	return w.queues
-}
-
 // Work starts processing jobs
 func (w *Worker) Work(ctx context.Context, jobs <-chan job.Job) error {
 	// Register worker
@@ -69,7 +59,7 @@ func (w *Worker) Work(ctx context.Context, jobs <-chan job.Job) error {
 		ID:       w.GetID(),
 		Hostname: w.hostname,
 		Pid:      w.pid,
-		Queues:   w.GetQueues(),
+		Queues:   w.broker.Queues(),
 		Started:  w.startTime,
 	}
 
@@ -108,7 +98,7 @@ func (w *Worker) processJob(ctx context.Context, job job.Job) {
 		ID:       w.GetID(),
 		Hostname: w.hostname,
 		Pid:      w.pid,
-		Queues:   w.GetQueues(),
+		Queues:   w.broker.Queues(),
 		Started:  w.startTime,
 	}
 

--- a/core/worker_pool.go
+++ b/core/worker_pool.go
@@ -16,7 +16,6 @@ type WorkerPool struct {
 	stats         Statistics
 	serializer    Serializer
 	concurrency   int
-	queues        []string
 	jobChan       <-chan job.Job
 	activeWorkers int32
 	workers       []*Worker
@@ -30,7 +29,6 @@ func NewWorkerPool(
 	stats Statistics,
 	serializer Serializer,
 	concurrency int,
-	queues []string,
 	jobChan <-chan job.Job,
 	broker Broker,
 ) *WorkerPool {
@@ -39,7 +37,6 @@ func NewWorkerPool(
 		stats:       stats,
 		serializer:  serializer,
 		concurrency: concurrency,
-		queues:      queues,
 		jobChan:     jobChan,
 		workers:     make([]*Worker, 0, concurrency),
 		broker:      broker,
@@ -54,7 +51,6 @@ func (wp *WorkerPool) Start(ctx context.Context) error {
 	for i := 0; i < wp.concurrency; i++ {
 		worker := NewWorker(
 			strconv.Itoa(i),
-			wp.queues,
 			wp.registry,
 			wp.stats,
 			wp.broker,

--- a/core/worker_pool.go
+++ b/core/worker_pool.go
@@ -14,7 +14,6 @@ import (
 type WorkerPool struct {
 	registry      Registry
 	stats         Statistics
-	serializer    Serializer
 	concurrency   int
 	jobChan       <-chan job.Job
 	activeWorkers int32
@@ -27,7 +26,6 @@ type WorkerPool struct {
 func NewWorkerPool(
 	registry Registry,
 	stats Statistics,
-	serializer Serializer,
 	concurrency int,
 	jobChan <-chan job.Job,
 	broker Broker,
@@ -35,7 +33,6 @@ func NewWorkerPool(
 	return &WorkerPool{
 		registry:    registry,
 		stats:       stats,
-		serializer:  serializer,
 		concurrency: concurrency,
 		jobChan:     jobChan,
 		workers:     make([]*Worker, 0, concurrency),

--- a/core/worker_pool_test.go
+++ b/core/worker_pool_test.go
@@ -30,7 +30,6 @@ func TestWorkerPool_Start_Basic(t *testing.T) {
 func TestWorkerPool_Start_JobProcessing(t *testing.T) {
 	registry := NewMockRegistry()
 	stats := NewMockStatistics()
-	serializer := NewMockSerializer()
 
 	broker := NewMockBroker()
 	jobChan := make(chan job.Job, 10)
@@ -43,7 +42,7 @@ func TestWorkerPool_Start_JobProcessing(t *testing.T) {
 		return nil
 	})
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, concurrency, jobChan, broker)
 
 	// Send some jobs
 	job1 := NewMockJob("TestJob", "queue1", []interface{}{"job1"})
@@ -77,7 +76,6 @@ func TestWorkerPool_Start_JobProcessing(t *testing.T) {
 func TestWorkerPool_Start_ConcurrentJobProcessing(t *testing.T) {
 	registry := NewMockRegistry()
 	stats := NewMockStatistics()
-	serializer := NewMockSerializer()
 
 	broker := NewMockBroker()
 	jobChan := make(chan job.Job, 10)
@@ -107,7 +105,7 @@ func TestWorkerPool_Start_ConcurrentJobProcessing(t *testing.T) {
 		return nil
 	})
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, concurrency, jobChan, broker)
 
 	// Send multiple jobs
 	numJobs := 5
@@ -137,7 +135,6 @@ func TestWorkerPool_Start_ConcurrentJobProcessing(t *testing.T) {
 func TestWorkerPool_Start_ContextCancellation(t *testing.T) {
 	registry := NewMockRegistry()
 	stats := NewMockStatistics()
-	serializer := NewMockSerializer()
 
 	broker := NewMockBroker()
 	jobChan := make(chan job.Job, 10)
@@ -151,7 +148,7 @@ func TestWorkerPool_Start_ContextCancellation(t *testing.T) {
 		return nil
 	})
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, concurrency, jobChan, broker)
 
 	// Send a job
 	job := NewMockJob("LongJob", "test-queue", []interface{}{})
@@ -189,13 +186,12 @@ func TestWorkerPool_Start_ContextCancellation(t *testing.T) {
 func TestWorkerPool_ActiveWorkers(t *testing.T) {
 	registry := NewMockRegistry()
 	stats := NewMockStatistics()
-	serializer := NewMockSerializer()
 
 	broker := NewMockBroker()
 	jobChan := make(chan job.Job, 10)
 	concurrency := 3
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, concurrency, jobChan, broker)
 
 	// Initially no active workers
 	assert.Equal(t, 0, pool.ActiveWorkers())
@@ -250,13 +246,12 @@ func TestWorkerPool_ActiveWorkers(t *testing.T) {
 func TestWorkerPool_Start_ZeroConcurrency(t *testing.T) {
 	registry := NewMockRegistry()
 	stats := NewMockStatistics()
-	serializer := NewMockSerializer()
 
 	broker := NewMockBroker()
 	jobChan := make(chan job.Job, 10)
 	concurrency := 0
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, concurrency, jobChan, broker)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -274,13 +269,12 @@ func TestWorkerPool_Start_ZeroConcurrency(t *testing.T) {
 func TestWorkerPool_Start_LargeConcurrency(t *testing.T) {
 	registry := NewMockRegistry()
 	stats := NewMockStatistics()
-	serializer := NewMockSerializer()
 
 	broker := NewMockBroker()
 	jobChan := make(chan job.Job, 10)
 	concurrency := 100
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, concurrency, jobChan, broker)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -297,7 +291,6 @@ func TestWorkerPool_Start_LargeConcurrency(t *testing.T) {
 func TestWorkerPool_Start_MultipleJobTypes(t *testing.T) {
 	registry := NewMockRegistry()
 	stats := NewMockStatistics()
-	serializer := NewMockSerializer()
 
 	broker := NewMockBroker()
 	jobChan := make(chan job.Job, 10)
@@ -314,7 +307,7 @@ func TestWorkerPool_Start_MultipleJobTypes(t *testing.T) {
 		return nil
 	})
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, concurrency, jobChan, broker)
 
 	// Send different job types
 	jobA1 := NewMockJob("JobA", "queue1", []interface{}{"a1"})
@@ -352,7 +345,6 @@ func TestWorkerPool_Start_MultipleJobTypes(t *testing.T) {
 func TestWorkerPool_Start_LongRunningJobs(t *testing.T) {
 	registry := NewMockRegistry()
 	stats := NewMockStatistics()
-	serializer := NewMockSerializer()
 
 	broker := NewMockBroker()
 	jobChan := make(chan job.Job, 10)
@@ -369,7 +361,7 @@ func TestWorkerPool_Start_LongRunningJobs(t *testing.T) {
 		return nil
 	})
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, concurrency, jobChan, broker)
 
 	// Send multiple long jobs
 	for i := 0; i < 4; i++ {

--- a/core/worker_pool_test.go
+++ b/core/worker_pool_test.go
@@ -43,7 +43,7 @@ func TestWorkerPool_Start_JobProcessing(t *testing.T) {
 		return nil
 	})
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, []string{"test-queue"}, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
 
 	// Send some jobs
 	job1 := NewMockJob("TestJob", "queue1", []interface{}{"job1"})
@@ -107,7 +107,7 @@ func TestWorkerPool_Start_ConcurrentJobProcessing(t *testing.T) {
 		return nil
 	})
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, []string{"test-queue"}, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
 
 	// Send multiple jobs
 	numJobs := 5
@@ -151,7 +151,7 @@ func TestWorkerPool_Start_ContextCancellation(t *testing.T) {
 		return nil
 	})
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, []string{"test-queue"}, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
 
 	// Send a job
 	job := NewMockJob("LongJob", "test-queue", []interface{}{})
@@ -195,7 +195,7 @@ func TestWorkerPool_ActiveWorkers(t *testing.T) {
 	jobChan := make(chan job.Job, 10)
 	concurrency := 3
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, []string{"test-queue"}, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
 
 	// Initially no active workers
 	assert.Equal(t, 0, pool.ActiveWorkers())
@@ -256,7 +256,7 @@ func TestWorkerPool_Start_ZeroConcurrency(t *testing.T) {
 	jobChan := make(chan job.Job, 10)
 	concurrency := 0
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, []string{"test-queue"}, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -280,7 +280,7 @@ func TestWorkerPool_Start_LargeConcurrency(t *testing.T) {
 	jobChan := make(chan job.Job, 10)
 	concurrency := 100
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, []string{"test-queue"}, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -314,7 +314,7 @@ func TestWorkerPool_Start_MultipleJobTypes(t *testing.T) {
 		return nil
 	})
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, []string{"test-queue"}, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
 
 	// Send different job types
 	jobA1 := NewMockJob("JobA", "queue1", []interface{}{"a1"})
@@ -369,7 +369,7 @@ func TestWorkerPool_Start_LongRunningJobs(t *testing.T) {
 		return nil
 	})
 
-	pool := NewWorkerPool(registry, stats, serializer, concurrency, []string{"test-queue"}, jobChan, broker)
+	pool := NewWorkerPool(registry, stats, serializer, concurrency, jobChan, broker)
 
 	// Send multiple long jobs
 	for i := 0; i < 4; i++ {

--- a/core/worker_test.go
+++ b/core/worker_test.go
@@ -54,7 +54,7 @@ func TestWorker_Work_JobFailure(t *testing.T) {
 		return testError
 	})
 
-	worker := NewWorker("test", []string{"test-queue"}, registry, stats, broker)
+	worker := NewWorker("test", registry, stats, broker)
 
 	// Create job channel and send a job
 	jobChan := make(chan job.Job, 1)
@@ -83,7 +83,7 @@ func TestWorker_Work_UnknownJob(t *testing.T) {
 
 	broker := NewMockBroker()
 
-	worker := NewWorker("test", []string{"test-queue"}, registry, stats, broker)
+	worker := NewWorker("test", registry, stats, broker)
 
 	// Create job channel with unknown job type
 	jobChan := make(chan job.Job, 1)
@@ -113,7 +113,7 @@ func TestWorker_Work_PanicRecovery(t *testing.T) {
 		panic("test panic")
 	})
 
-	worker := NewWorker("test", []string{"test-queue"}, registry, stats, broker)
+	worker := NewWorker("test", registry, stats, broker)
 
 	// Create job channel and send a job
 	jobChan := make(chan job.Job, 1)
@@ -138,7 +138,7 @@ func TestWorker_Work_ContextCancellation(t *testing.T) {
 
 	broker := NewMockBroker()
 
-	worker := NewWorker("test", []string{"test-queue"}, registry, stats, broker)
+	worker := NewWorker("test", registry, stats, broker)
 
 	// Create job channel but don't send any jobs
 	jobChan := make(chan job.Job)
@@ -157,7 +157,7 @@ func TestWorker_Work_ChannelClosed(t *testing.T) {
 
 	broker := NewMockBroker()
 
-	worker := NewWorker("test", []string{"test-queue"}, registry, stats, broker)
+	worker := NewWorker("test", registry, stats, broker)
 
 	// Create job channel and close it immediately
 	jobChan := make(chan job.Job)
@@ -183,7 +183,7 @@ func TestWorker_Work_StatisticsErrors(t *testing.T) {
 		return nil
 	})
 
-	worker := NewWorker("test", []string{"test-queue"}, registry, stats, broker)
+	worker := NewWorker("test", registry, stats, broker)
 
 	// Create job channel and send a job
 	jobChan := make(chan job.Job, 1)
@@ -216,7 +216,7 @@ func TestWorker_Work_BrokerErrors(t *testing.T) {
 		return nil
 	})
 
-	worker := NewWorker("test", []string{"test-queue"}, registry, stats, broker)
+	worker := NewWorker("test", registry, stats, broker)
 
 	// Create job channel and send a job
 	jobChan := make(chan job.Job, 1)
@@ -244,7 +244,7 @@ func TestWorker_ProcessMultipleJobs(t *testing.T) {
 		return nil
 	})
 
-	worker := NewWorker("test", []string{"test-queue"}, registry, stats, broker)
+	worker := NewWorker("test", registry, stats, broker)
 
 	// Create job channel with multiple jobs
 	jobChan := make(chan job.Job, 3)
@@ -282,7 +282,7 @@ func TestWorker_LongRunningJob(t *testing.T) {
 		return nil
 	})
 
-	worker := NewWorker("test", []string{"test-queue"}, registry, stats, broker)
+	worker := NewWorker("test", registry, stats, broker)
 
 	// Create job channel
 	jobChan := make(chan job.Job, 1)

--- a/doc.go
+++ b/doc.go
@@ -83,7 +83,6 @@
 //			broker,    // implements core.Broker
 //			stats,     // implements core.Statistics
 //			reg,       // implements core.Registry
-//			serializer, // implements core.Serializer
 //			core.WithConcurrency(10),
 //			core.WithShutdownTimeout(30*time.Second),
 //		)

--- a/doc.go
+++ b/doc.go
@@ -8,7 +8,7 @@
 // # Architecture
 //
 // goworker uses dependency injection with these core components:
-//   - Broker: Handles queue operations (Redis, RabbitMQ)
+//   - Broker: Handles queue operations and job consumption (Redis, RabbitMQ)
 //   - Statistics: Records metrics and monitoring data
 //   - Registry: Maps job classes to worker functions
 //   - Serializer: Converts jobs to/from bytes
@@ -26,7 +26,11 @@
 //	}
 //
 //	func main() {
-//		engine := engines.NewResqueEngine(engines.DefaultResqueOptions())
+//		options := engines.DefaultResqueOptions()
+//		options.Queues = []string{"email", "default"}
+//		options.PollInterval = 3 * time.Second
+//
+//		engine := engines.NewResqueEngine(options)
 //		engine.Register("EmailJob", emailJob)
 //		engine.Run(context.Background())
 //	}
@@ -41,7 +45,10 @@
 //	}
 //
 //	func main() {
-//		engine := engines.NewSneakersEngine(engines.DefaultSneakersOptions())
+//		options := engines.DefaultSneakersOptions()
+//		options.Queues = []string{"images", "default"}
+//
+//		engine := engines.NewSneakersEngine(options)
 //		engine.Register("ImageProcessor", imageProcessor)
 //		engine.Run(context.Background())
 //	}
@@ -60,11 +67,16 @@
 //	)
 //
 //	func main() {
+//		// Configure broker with queues
+//		brokerOpts := redis.DefaultOptions()
+//		brokerOpts.Queues = []string{"critical", "default"}
+//		brokerOpts.PollInterval = 5 * time.Second
+//
 //		// Create components
-//		broker := redis.NewBroker(redis.DefaultOptions(), resque.NewSerializer())
+//		serializer := resque.NewSerializer()
+//		broker := redis.NewBroker(brokerOpts, serializer)
 //		stats := resque.NewStatistics(resque.DefaultOptions())
 //		reg := registry.NewRegistry()
-//		serializer := resque.NewSerializer()
 //
 //		// Create engine
 //		engine := core.NewEngine(
@@ -73,7 +85,7 @@
 //			reg,       // implements core.Registry
 //			serializer, // implements core.Serializer
 //			core.WithConcurrency(10),
-//			core.WithQueues([]string{"critical", "default"}),
+//			core.WithShutdownTimeout(30*time.Second),
 //		)
 //
 //		// Register workers
@@ -119,10 +131,12 @@
 // ResqueEngine: Redis + Resque serializer + Resque statistics
 // - Compatible with Ruby Resque
 // - Uses Redis for queuing and statistics
+// - Configure queues and poll interval via ResqueOptions
 //
 // SneakersEngine: RabbitMQ + Sneakers serializer + NoOp statistics
 // - Compatible with Rails ActiveJob/Sneakers
 // - Uses RabbitMQ for queuing
+// - Configure queues via SneakersOptions
 //
 // # Health Monitoring
 //

--- a/engines/README.md
+++ b/engines/README.md
@@ -14,8 +14,10 @@ Redis-based engine with Ruby Resque compatibility.
 **Options:**
 ```go
 type ResqueOptions struct {
-    RedisURI      string         // Default: redis://localhost:6379/
-    RedisOptions  redis.Options  // Detailed Redis configuration
+    RedisURI      string               // Default: redis://localhost:6379/
+    RedisOptions  redis.Options        // Detailed Redis configuration
+    Queues        []string             // Queues to consume from
+    PollInterval  time.Duration        // Polling interval for jobs
     EngineOptions []core.EngineOption
 }
 ```
@@ -34,7 +36,8 @@ RabbitMQ-based engine with Rails ActiveJob compatibility.
 type SneakersOptions struct {
     RabbitMQURI     string                // Default: amqp://guest:guest@localhost:5672/
     RabbitMQOptions rabbitmq.Options      // Detailed RabbitMQ configuration
-    Statistics      interfaces.Statistics // Optional custom statistics
+    Queues          []string              // Queues to consume from
+    Statistics      core.Statistics       // Optional custom statistics
     EngineOptions   []core.EngineOption
 }
 ```
@@ -61,9 +64,18 @@ All pre-configured engines provide:
 
 ## Customization
 
-Override statistics for SneakersEngine:
+Configure queues for ResqueEngine:
+```go
+options := engines.DefaultResqueOptions()
+options.Queues = []string{"high", "medium", "low"}
+options.PollInterval = 3 * time.Second
+engine := engines.NewResqueEngine(options)
+```
+
+Configure queues and statistics for SneakersEngine:
 ```go
 options := engines.DefaultSneakersOptions()
+options.Queues = []string{"activejob", "images"}
 options.Statistics = resque.NewStatistics(resque.DefaultOptions())
 engine := engines.NewSneakersEngine(options)
 ```

--- a/engines/resque.go
+++ b/engines/resque.go
@@ -23,6 +23,7 @@ package engines
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/BranchIntl/goworker2/brokers/redis"
 	"github.com/BranchIntl/goworker2/core"
@@ -35,6 +36,8 @@ import (
 type ResqueOptions struct {
 	RedisURI      string
 	RedisOptions  redis.Options
+	Queues        []string
+	PollInterval  time.Duration
 	EngineOptions []core.EngineOption
 }
 
@@ -43,6 +46,8 @@ func DefaultResqueOptions() ResqueOptions {
 	return ResqueOptions{
 		RedisURI:      "redis://localhost:6379/",
 		RedisOptions:  redis.DefaultOptions(),
+		Queues:        []string{},
+		PollInterval:  5 * time.Second,
 		EngineOptions: []core.EngineOption{},
 	}
 }
@@ -62,6 +67,10 @@ func NewResqueEngine(options ResqueOptions) *ResqueEngine {
 	if options.RedisURI != "" {
 		options.RedisOptions.URI = options.RedisURI
 	}
+
+	// Configure queues and poll interval
+	options.RedisOptions.Queues = options.Queues
+	options.RedisOptions.PollInterval = options.PollInterval
 
 	// Create components
 	serializer := resque.NewSerializer()

--- a/engines/resque.go
+++ b/engines/resque.go
@@ -88,7 +88,6 @@ func NewResqueEngine(options ResqueOptions) *ResqueEngine {
 		broker,
 		stats,
 		registry,
-		serializer,
 		options.EngineOptions...,
 	)
 

--- a/engines/resque_test.go
+++ b/engines/resque_test.go
@@ -13,10 +13,9 @@ import (
 
 func TestResqueEngine_ConfigurationOverride(t *testing.T) {
 	tests := []struct {
-		name       string
-		redisURI   string
-		redisOpts  redis.Options
-		expectType string
+		name      string
+		redisURI  string
+		redisOpts redis.Options
 	}{
 		{
 			name:     "URI overrides options",
@@ -25,7 +24,6 @@ func TestResqueEngine_ConfigurationOverride(t *testing.T) {
 				URI:       "redis://original:6379/",
 				Namespace: "test:",
 			},
-			expectType: "redis",
 		},
 		{
 			name:     "empty URI uses options",
@@ -34,7 +32,6 @@ func TestResqueEngine_ConfigurationOverride(t *testing.T) {
 				URI:       "redis://from-options:6379/",
 				Namespace: "test:",
 			},
-			expectType: "redis",
 		},
 	}
 
@@ -46,8 +43,7 @@ func TestResqueEngine_ConfigurationOverride(t *testing.T) {
 				EngineOptions: []core.EngineOption{},
 			}
 
-			engine := NewResqueEngine(options)
-			assert.Equal(t, tt.expectType, engine.broker.Type())
+			NewResqueEngine(options)
 		})
 	}
 }
@@ -94,4 +90,26 @@ func TestResqueEngine_MustPanicOnError(t *testing.T) {
 	assert.Panics(t, func() {
 		engine.MustStart(ctx)
 	})
+}
+
+func TestResqueEngine_QueueConfiguration(t *testing.T) {
+	options := DefaultResqueOptions()
+	options.Queues = []string{"high", "medium", "low"}
+	options.PollInterval = 3 * time.Second
+
+	engine := NewResqueEngine(options)
+
+	// Verify that queues are configured on the broker
+	brokerQueues := engine.broker.Queues()
+	assert.Equal(t, []string{"high", "medium", "low"}, brokerQueues)
+}
+
+func TestResqueEngine_DefaultQueueConfiguration(t *testing.T) {
+	options := DefaultResqueOptions()
+
+	engine := NewResqueEngine(options)
+
+	// Verify that default empty queues are used
+	brokerQueues := engine.broker.Queues()
+	assert.Equal(t, []string{}, brokerQueues)
 }

--- a/engines/sneakers.go
+++ b/engines/sneakers.go
@@ -15,6 +15,7 @@ import (
 type SneakersOptions struct {
 	RabbitMQURI     string
 	RabbitMQOptions rabbitmq.Options
+	Queues          []string
 	Statistics      core.Statistics
 	EngineOptions   []core.EngineOption
 }
@@ -24,6 +25,7 @@ func DefaultSneakersOptions() SneakersOptions {
 	return SneakersOptions{
 		RabbitMQURI:     "amqp://guest:guest@localhost:5672/",
 		RabbitMQOptions: rabbitmq.DefaultOptions(),
+		Queues:          []string{},
 		Statistics:      noop.NewStatistics(),
 		EngineOptions:   []core.EngineOption{},
 	}
@@ -44,6 +46,9 @@ func NewSneakersEngine(options SneakersOptions) *SneakersEngine {
 	if options.RabbitMQURI != "" {
 		options.RabbitMQOptions.URI = options.RabbitMQURI
 	}
+
+	// Configure queues
+	options.RabbitMQOptions.Queues = options.Queues
 
 	// Create components
 	serializer := sneakers.NewSerializer()

--- a/engines/sneakers.go
+++ b/engines/sneakers.go
@@ -66,7 +66,6 @@ func NewSneakersEngine(options SneakersOptions) *SneakersEngine {
 		broker,
 		stats,
 		registry,
-		serializer,
 		options.EngineOptions...,
 	)
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -18,6 +18,7 @@ var (
 	ErrInvalidConfig  = errors.New("invalid configuration")
 	ErrEmptyClassName = errors.New("class name cannot be empty")
 	ErrNilWorkerFunc  = errors.New("worker function cannot be nil")
+	ErrNoQueues       = errors.New("no queues specified")
 )
 
 // BrokerError represents broker-specific errors
@@ -136,4 +137,26 @@ func IsTimeout(err error) bool {
 		return t.Timeout()
 	}
 	return errors.Is(err, ErrTimeout)
+}
+
+// Standard functions
+
+func As(err error, target any) bool {
+	return errors.As(err, target)
+}
+
+func Is(err, target error) bool {
+	return errors.Is(err, target)
+}
+
+func Join(errs ...error) error {
+	return errors.Join(errs...)
+}
+
+func New(text string) error {
+	return errors.New(text)
+}
+
+func Unwrap(err error) error {
+	return errors.Unwrap(err)
 }

--- a/examples/rabbitmq-advanced/main.go
+++ b/examples/rabbitmq-advanced/main.go
@@ -61,7 +61,6 @@ func main() {
 		broker,
 		stats,
 		reg,
-		serializer,
 		core.WithConcurrency(5),
 		core.WithShutdownTimeout(45*time.Second),
 		core.WithJobBufferSize(50),

--- a/examples/rabbitmq-basic/main.go
+++ b/examples/rabbitmq-basic/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/BranchIntl/goworker2/core"
 	"github.com/BranchIntl/goworker2/engines"
@@ -19,10 +18,9 @@ func main() {
 	// Create a pre-configured Sneakers engine (RabbitMQ + Sneakers serializer + NoOp stats)
 	options := engines.DefaultSneakersOptions()
 	options.RabbitMQURI = "amqp://guest:guest@localhost:5672/"
+	options.Queues = []string{"myqueue"}
 	options.EngineOptions = []core.EngineOption{
 		core.WithConcurrency(2),
-		core.WithQueues([]string{"myqueue"}),
-		core.WithPollInterval(5 * time.Second),
 	}
 
 	engine := engines.NewSneakersEngine(options)

--- a/examples/redis-advanced/main.go
+++ b/examples/redis-advanced/main.go
@@ -31,6 +31,8 @@ func main() {
 	brokerOpts := redis.DefaultOptions()
 	brokerOpts.URI = "redis://localhost:6379/"
 	brokerOpts.Namespace = "resque:"
+	brokerOpts.Queues = []string{"critical", "default", "low"}
+	brokerOpts.PollInterval = 2 * time.Second
 	brokerOpts.MaxConnections = 20
 	brokerOpts.MaxIdle = 5
 	brokerOpts.ConnectTimeout = 15 * time.Second
@@ -59,8 +61,6 @@ func main() {
 		reg,
 		serializer,
 		core.WithConcurrency(10),
-		core.WithQueues([]string{"critical", "default", "low"}),
-		core.WithPollInterval(2*time.Second),
 		core.WithShutdownTimeout(30*time.Second),
 		core.WithJobBufferSize(200),
 	)

--- a/examples/redis-advanced/main.go
+++ b/examples/redis-advanced/main.go
@@ -59,7 +59,6 @@ func main() {
 		broker,
 		stats,
 		reg,
-		serializer,
 		core.WithConcurrency(10),
 		core.WithShutdownTimeout(30*time.Second),
 		core.WithJobBufferSize(200),

--- a/examples/redis-basic/main.go
+++ b/examples/redis-basic/main.go
@@ -19,10 +19,10 @@ func main() {
 	// Create a pre-configured Resque engine (Redis + Resque serializer + Resque stats)
 	options := engines.DefaultResqueOptions()
 	options.RedisURI = "redis://localhost:6379/"
+	options.Queues = []string{"myqueue"}
+	options.PollInterval = 5 * time.Second
 	options.EngineOptions = []core.EngineOption{
 		core.WithConcurrency(2),
-		core.WithQueues([]string{"myqueue"}),
-		core.WithPollInterval(5 * time.Second),
 	}
 
 	engine := engines.NewResqueEngine(options)

--- a/job/types.go
+++ b/job/types.go
@@ -1,3 +1,8 @@
+// Package job defines the core job interface and related types for the goworker library.
+//
+// This package provides the fundamental Job interface that represents a unit of work
+// to be processed by workers, along with supporting types for job payloads and metadata.
+// All job implementations across different serializers must implement the Job interface.
 package job
 
 import "time"

--- a/pollers/broker.go
+++ b/pollers/broker.go
@@ -1,0 +1,12 @@
+package pollers
+
+import (
+	"context"
+
+	"github.com/BranchIntl/goworker2/job"
+)
+
+type Broker interface {
+	Dequeue(ctx context.Context, queue string) (job.Job, error)
+	Nack(ctx context.Context, job job.Job, requeue bool) error
+}

--- a/pollers/mocks_test.go
+++ b/pollers/mocks_test.go
@@ -1,0 +1,169 @@
+package pollers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/BranchIntl/goworker2/job"
+)
+
+// MockBroker implements the pollers.Broker interface for testing
+type MockBroker struct {
+	mu                       sync.RWMutex
+	dequeueError             error
+	nackError                error
+	queues                   map[string][]job.Job
+	nackedJobs               []job.Job
+	shouldReturnNilOnDequeue bool
+}
+
+func NewMockBroker() *MockBroker {
+	return &MockBroker{
+		queues:     make(map[string][]job.Job),
+		nackedJobs: make([]job.Job, 0),
+	}
+}
+
+func (m *MockBroker) Dequeue(ctx context.Context, queue string) (job.Job, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.dequeueError != nil {
+		return nil, m.dequeueError
+	}
+
+	if m.shouldReturnNilOnDequeue {
+		return nil, nil
+	}
+
+	jobs, exists := m.queues[queue]
+	if !exists || len(jobs) == 0 {
+		return nil, nil
+	}
+
+	job := jobs[0]
+	m.queues[queue] = jobs[1:]
+	return job, nil
+}
+
+func (m *MockBroker) Nack(ctx context.Context, jobArg job.Job, requeue bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.nackError != nil {
+		return m.nackError
+	}
+
+	m.nackedJobs = append(m.nackedJobs, jobArg)
+	if requeue {
+		if m.queues[jobArg.GetQueue()] == nil {
+			m.queues[jobArg.GetQueue()] = make([]job.Job, 0)
+		}
+		m.queues[jobArg.GetQueue()] = append(m.queues[jobArg.GetQueue()], jobArg)
+	}
+	return nil
+}
+
+// Test helpers
+func (m *MockBroker) SetDequeueError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dequeueError = err
+}
+
+func (m *MockBroker) SetShouldReturnNilOnDequeue(shouldReturn bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.shouldReturnNilOnDequeue = shouldReturn
+}
+
+func (m *MockBroker) GetNackedJobs() []job.Job {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return append([]job.Job(nil), m.nackedJobs...)
+}
+
+func (m *MockBroker) AddJobToQueue(queue string, jobArg job.Job) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.queues[queue] == nil {
+		m.queues[queue] = make([]job.Job, 0)
+	}
+	m.queues[queue] = append(m.queues[queue], jobArg)
+}
+
+// MockJob implements the job.Job interface for testing
+type MockJob struct {
+	id         string
+	queue      string
+	class      string
+	args       []interface{}
+	metadata   job.Metadata
+	enqueuedAt time.Time
+	retryCount int
+	lastError  string
+}
+
+func NewMockJob(class, queue string, args []interface{}) *MockJob {
+	return &MockJob{
+		id:         fmt.Sprintf("job-%d", time.Now().UnixNano()),
+		queue:      queue,
+		class:      class,
+		args:       args,
+		enqueuedAt: time.Now(),
+		metadata: job.Metadata{
+			Queue:      queue,
+			EnqueuedAt: time.Now(),
+		},
+	}
+}
+
+func (m *MockJob) GetID() string {
+	return m.id
+}
+
+func (m *MockJob) GetQueue() string {
+	return m.queue
+}
+
+func (m *MockJob) GetClass() string {
+	return m.class
+}
+
+func (m *MockJob) GetArgs() []interface{} {
+	return m.args
+}
+
+func (m *MockJob) GetMetadata() job.Metadata {
+	return m.metadata
+}
+
+func (m *MockJob) GetEnqueuedAt() time.Time {
+	return m.enqueuedAt
+}
+
+func (m *MockJob) GetRetryCount() int {
+	return m.retryCount
+}
+
+func (m *MockJob) GetLastError() string {
+	return m.lastError
+}
+
+func (m *MockJob) SetRetryCount(count int) {
+	m.retryCount = count
+}
+
+func (m *MockJob) SetLastError(err string) {
+	m.lastError = err
+}
+
+func (m *MockJob) GetPayload() job.Payload {
+	return job.Payload{
+		Class: m.class,
+		Args:  m.args,
+	}
+}

--- a/pollers/poller.go
+++ b/pollers/poller.go
@@ -1,17 +1,17 @@
-package core
+package pollers
 
 import (
 	"context"
 	"log/slog"
 	"time"
 
+	"github.com/BranchIntl/goworker2/errors"
 	"github.com/BranchIntl/goworker2/job"
 )
 
 // StandardPoller is a broker-agnostic job poller for pull-based brokers
 type StandardPoller struct {
 	broker   Broker
-	stats    Statistics
 	queues   []string
 	interval time.Duration
 }
@@ -19,13 +19,11 @@ type StandardPoller struct {
 // NewStandardPoller creates a new standard poller
 func NewStandardPoller(
 	broker Broker,
-	stats Statistics,
 	queues []string,
 	interval time.Duration,
 ) *StandardPoller {
 	return &StandardPoller{
 		broker:   broker,
-		stats:    stats,
 		queues:   queues,
 		interval: interval,
 	}
@@ -35,40 +33,37 @@ func NewStandardPoller(
 func (p *StandardPoller) Start(ctx context.Context, jobChan chan<- job.Job) error {
 	slog.Info("StandardPoller started", "queues", p.queues)
 
+	defer func() {
+		close(jobChan)
+		slog.Info("StandardPoller stopped")
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():
-			close(jobChan)
-			slog.Info("StandardPoller stopped")
 			return nil
 		default:
 			job, err := p.pollOnce(ctx)
 			if err != nil {
 				slog.Error("Error polling", "error", err)
-				// Brief pause on error
-				time.Sleep(time.Second)
-				continue
+				return err
 			}
 
 			if job != nil {
 				select {
-				case <-ctx.Done():
-					// Put job back on queue
+				case jobChan <- job:
+					slog.Debug("Job sent to workers", "class", job.GetClass())
+				default:
+					// This should never happen with enough buffer
+					slog.Error("Job channel is full", "class", job.GetClass())
 					if err := p.broker.Nack(ctx, job, true); err != nil {
 						slog.Error("Error requeueing job", "error", err)
 					}
-					close(jobChan)
-					slog.Info("StandardPoller stopped")
-					return nil
-				case jobChan <- job:
-					slog.Debug("Job sent to workers", "class", job.GetClass())
 				}
 			} else {
 				// No job found, wait before polling again
 				select {
 				case <-ctx.Done():
-					close(jobChan)
-					slog.Info("StandardPoller stopped")
 					return nil
 				case <-time.After(p.interval):
 				}
@@ -80,6 +75,9 @@ func (p *StandardPoller) Start(ctx context.Context, jobChan chan<- job.Job) erro
 // pollOnce attempts to get a job from the queues
 func (p *StandardPoller) pollOnce(ctx context.Context) (job.Job, error) {
 	queues := p.queues
+	if len(queues) == 0 {
+		return nil, errors.ErrNoQueues
+	}
 
 	for _, queue := range queues {
 		slog.Debug("Checking queue", "queue", queue)


### PR DESCRIPTION
### Summary
This PR introduces a major architectural refactoring to improve modularity, simplify core components, and clarify responsibilities. The core idea is to make brokers more self-contained by moving job consumption logic (polling/push) and serialization into the broker implementations.

### Key Changes:

*   **Simplified `Broker` Interface**:
    *   The `Broker` interface is streamlined. Methods like `Dequeue`, `CreateQueue`, and `Capabilities` have been removed from the `core.Broker` interface.
    *   A new `Start(ctx context.Context, jobChan chan<- job.Job)` method is introduced. Each broker is now responsible for fetching jobs and sending them to the provided channel.
    *   A `Queues()` method was added to provide queue information.

*   **Removed `Poller` from Core**:
    *   The `Poller` interface and `StandardPoller` have been removed from the `core` package.
    *   Pull-based brokers (like Redis) now manage their own polling loop internally. A new `pollers` package contains a helper `StandardPoller` for this.
    *   Push-based brokers (like RabbitMQ) implement their consumer logic directly in the `Start` method.

*   **Decoupled `Serializer` from Engine**:
    *   The `Serializer` is no longer a core component passed to the `Engine`.
    *   Instead, each `Broker` is now responsible for its own serialization and receives a `Serializer` on initialization. This better encapsulates the data format with the transport layer.

*   **Configuration Moved to Brokers**:
    *   Configuration for `Queues` and `PollInterval` has been removed from `core.Engine` options.
    *   This configuration is now part of the `Options` for each respective broker (`redis.Options`, `rabbitmq.Options`), making them more self-contained and easier to configure.

*   **Simplified Core and Engine**:
    *   The `core.Engine` is simplified. It no longer needs to create or manage a `Poller`. It just calls `broker.Start()`.
    *   `Worker` and `WorkerPool` are also simplified, as they no longer need `queues` or a `serializer` during initialization.