### PR TITLE
Add support for quorum queues in goworker2

### DIFF
--- a/brokers/rabbitmq/broker_helper.go
+++ b/brokers/rabbitmq/broker_helper.go
@@ -1,0 +1,37 @@
+package rabbitmq
+
+import (
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+// buildQueueArgs creates the AMQP arguments table from options
+func (r *RabbitMQBroker) buildQueueArgs(options QueueOptions) amqp.Table {
+	args := amqp.Table{}
+
+	// Set message TTL if specified
+	if options.MessageTTL > 0 {
+		args["x-message-ttl"] = int64(options.MessageTTL / time.Millisecond)
+	}
+
+	// Set dead letter exchange if specified
+	if options.DeadLetterQueue != "" {
+		args["x-dead-letter-exchange"] = ""
+		args["x-dead-letter-routing-key"] = options.DeadLetterQueue
+	}
+
+	// Set max retries if specified
+	if options.MaxRetries > 0 {
+		args["x-max-retries"] = options.MaxRetries
+		// For Quorum Queues (and generally good practice in newer RMQ), map to x-delivery-limit
+		args["x-delivery-limit"] = options.MaxRetries
+	}
+
+	// Set queue type if specified
+	if options.QueueType != "" {
+		args["x-queue-type"] = options.QueueType
+	}
+
+	return args
+}

--- a/brokers/rabbitmq/broker_helper_test.go
+++ b/brokers/rabbitmq/broker_helper_test.go
@@ -1,0 +1,81 @@
+package rabbitmq
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildQueueArgs(t *testing.T) {
+	broker := &RabbitMQBroker{}
+
+	tests := []struct {
+		name     string
+		options  QueueOptions
+		expected map[string]interface{}
+	}{
+		{
+			name:     "empty options",
+			options:  QueueOptions{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name: "quorum queue type",
+			options: QueueOptions{
+				QueueType: "quorum",
+			},
+			expected: map[string]interface{}{
+				"x-queue-type": "quorum",
+			},
+		},
+		{
+			name: "max retries sets delivery limit",
+			options: QueueOptions{
+				MaxRetries: 5,
+			},
+			expected: map[string]interface{}{
+				"x-max-retries":    5,
+				"x-delivery-limit": 5,
+			},
+		},
+		{
+			name: "classic queue with TTL and DLQ",
+			options: QueueOptions{
+				MessageTTL:      60 * time.Second,
+				DeadLetterQueue: "dlq-exchange",
+			},
+			expected: map[string]interface{}{
+				"x-message-ttl":             int64(60000),
+				"x-dead-letter-exchange":    "",
+				"x-dead-letter-routing-key": "dlq-exchange",
+			},
+		},
+		{
+			name: "quorum queue with max retries",
+			options: QueueOptions{
+				QueueType:  "quorum",
+				MaxRetries: 3,
+			},
+			expected: map[string]interface{}{
+				"x-queue-type":     "quorum",
+				"x-max-retries":    3,
+				"x-delivery-limit": 3,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := broker.buildQueueArgs(tt.options)
+
+			// Check that all expected keys exist and match
+			for k, v := range tt.expected {
+				assert.Equal(t, v, args[k], "Value mismatch for key %s", k)
+			}
+
+			// Check that no extra keys exist
+			assert.Equal(t, len(tt.expected), len(args), "Unexpected number of arguments")
+		})
+	}
+}


### PR DESCRIPTION
`QueueOptions` now supports `QueueType` which is sent as `x-queue-type`.

We also set `x-delivery-limit` in addition to `x-max-retries`. The former allows us to use built-in support for handling poison payloads.